### PR TITLE
Add space world make target

### DIFF
--- a/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo-classic.cmake
+++ b/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo-classic.cmake
@@ -114,6 +114,7 @@ if(gazebo_FOUND)
 		warehouse
 		windy
 		yosemite
+		space
 	)
 
 	# find corresponding airframes


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This PR adds a zero gravity world named `space` for testing microgravity environments

### Test coverage
- To run the world, simply run the following command

```
make px4_sitl gazebo-classic_<name_of_vehicle>__space
```
e.g.
```
make px4_sitl gazebo-classic_iris__space
```


### Context
- This PR