### PR TITLE
PWM Hardware Replication

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/9000_gazebo-classic_2d_spacecraft
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/9000_gazebo-classic_2d_spacecraft
@@ -88,14 +88,17 @@ param set-default CA_THRUSTER7_AX 0.0
 param set-default CA_THRUSTER7_AY -1.0
 param set-default CA_THRUSTER7_AZ 0.0
 
-param set-default PWM_MAIN_FUNC1 101
-param set-default PWM_MAIN_FUNC2 102
-param set-default PWM_MAIN_FUNC3 103
-param set-default PWM_MAIN_FUNC4 104
-param set-default PWM_MAIN_FUNC5 105
-param set-default PWM_MAIN_FUNC6 106
-param set-default PWM_MAIN_FUNC7 107
-param set-default PWM_MAIN_FUNC8 108
+param set-default PWM_MAIN_FUNC1 501
+param set-default PWM_MAIN_FUNC2 502
+param set-default PWM_MAIN_FUNC3 503
+param set-default PWM_MAIN_FUNC4 504
+param set-default PWM_MAIN_FUNC5 505
+param set-default PWM_MAIN_FUNC6 506
+param set-default PWM_MAIN_FUNC7 507
+param set-default PWM_MAIN_FUNC8 508
+
+param set PWM_SIM_PWM_MAX 10000
+param set PWM_SIM_PWM_MIN 0
 
 # Controller Tunings
 param set-default SC_ROLLRATE_P 0.14

--- a/ROMFS/px4fmu_common/init.d/rc.vehicle_setup
+++ b/ROMFS/px4fmu_common/init.d/rc.vehicle_setup
@@ -60,7 +60,7 @@ then
 fi
 
 #
-# SR setup
+# Spacecraft setup
 #
 if [ $VEHICLE_TYPE = sc ]
 then

--- a/src/modules/simulation/pwm_out_sim/PWMSim.cpp
+++ b/src/modules/simulation/pwm_out_sim/PWMSim.cpp
@@ -44,11 +44,16 @@
 PWMSim::PWMSim(bool hil_mode_enabled) :
 	OutputModuleInterface(MODULE_NAME, px4::wq_configurations::hp_default)
 {
+	// initialize parameters - dynamic instead of static
+	PWM_SIM_PWM_MAX_MAGIC = _param_pwm_sim_max_magic.get();
+	PWM_SIM_PWM_MIN_MAGIC = _param_pwm_sim_min_magic.get();
+	PWM_SIM_FAILSAFE_MAGIC = _param_pwm_sim_failsafe_magic.get();
+	PWM_SIM_DISARMED_MAGIC = _param_pwm_sim_disarmed_magic.get();
+
 	_mixing_output.setAllDisarmedValues(PWM_SIM_DISARMED_MAGIC);
 	_mixing_output.setAllFailsafeValues(PWM_SIM_FAILSAFE_MAGIC);
 	_mixing_output.setAllMinValues(PWM_SIM_PWM_MIN_MAGIC);
 	_mixing_output.setAllMaxValues(PWM_SIM_PWM_MAX_MAGIC);
-
 	_mixing_output.setIgnoreLockdown(hil_mode_enabled);
 }
 

--- a/src/modules/simulation/pwm_out_sim/PWMSim.hpp
+++ b/src/modules/simulation/pwm_out_sim/PWMSim.hpp
@@ -38,7 +38,9 @@
 #include <drivers/drv_pwm_output.h>
 #include <lib/mixer_module/mixer_module.hpp>
 #include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/defines.h>
 #include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
 #include <px4_platform_common/tasks.h>
 #include <px4_platform_common/time.h>
 #include <uORB/topics/parameter_update.h>
@@ -76,10 +78,10 @@ public:
 private:
 	void Run() override;
 
-	static constexpr uint16_t PWM_SIM_DISARMED_MAGIC = 900;
-	static constexpr uint16_t PWM_SIM_FAILSAFE_MAGIC = 600;
-	static constexpr uint16_t PWM_SIM_PWM_MIN_MAGIC = 1000;
-	static constexpr uint16_t PWM_SIM_PWM_MAX_MAGIC = 2000;
+	uint16_t PWM_SIM_DISARMED_MAGIC;
+	uint16_t PWM_SIM_FAILSAFE_MAGIC;
+	uint16_t PWM_SIM_PWM_MIN_MAGIC;
+	uint16_t PWM_SIM_PWM_MAX_MAGIC;
 
 	MixingOutput _mixing_output{PARAM_PREFIX, MAX_ACTUATORS, *this, MixingOutput::SchedulingPolicy::Auto, false, false};
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
@@ -88,4 +90,11 @@ private:
 
 	perf_counter_t	_cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 	perf_counter_t	_interval_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": interval")};
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::PWM_SIM_PWM_MAX>) _param_pwm_sim_max_magic,
+		(ParamInt<px4::params::PWM_SIM_PWM_MIN>) _param_pwm_sim_min_magic,
+		(ParamInt<px4::params::PWM_SIM_FAILSAFE>) _param_pwm_sim_failsafe_magic,
+		(ParamInt<px4::params::PWM_SIM_DISARM>) _param_pwm_sim_disarmed_magic
+	)
 };

--- a/src/modules/simulation/pwm_out_sim/pwm_out_sim_params.c
+++ b/src/modules/simulation/pwm_out_sim/pwm_out_sim_params.c
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2013-2015 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file pwm_out_sim_params.c
+ * Parameters for PWM output simulator.
+ *
+ * @author Pedro Roque, <padr@kth.se>
+ */
+
+/**
+ * Maximum PWM Value
+ *
+ * Highest PWM value that can be output by the simulator.
+ *
+ * @min 0
+ * @max 10000
+ * @decimal 0
+ * @increment 1
+ * @group PWM Output Simulator
+ */
+PARAM_DEFINE_INT32(PWM_SIM_PWM_MAX, 2000);
+
+/**
+ * Minimum PWM Value
+ *
+ * Lowest PWM value that can be output by the simulator.
+ *
+ * @min -10000
+ * @max 2000
+ * @decimal 0
+ * @increment 1
+ * @group PWM Output Simulator
+ */
+PARAM_DEFINE_INT32(PWM_SIM_PWM_MIN, 1000);
+
+/**
+ * Failsafe PWM Value
+ *
+ * Output at Failsafe level.
+ *
+ * @min 0
+ * @max 10000
+ * @decimal 0
+ * @increment 1
+ * @group PWM Output Simulator
+ */
+PARAM_DEFINE_INT32(PWM_SIM_FAILSAFE, 600);
+
+/**
+ * Disarm PWM Value
+ *
+ * Output at Disarmed state.
+ *
+ * @min 0
+ * @max 10000
+ * @decimal 0
+ * @increment 1
+ * @group PWM Output Simulator
+ */
+PARAM_DEFINE_INT32(PWM_SIM_DISARM, 900);


### PR DESCRIPTION
Added parameters to replicate hardware PWM levels vs Simulation. 

Better solution could be to avoid PWMSim entirely, something to decide later.