### PR TITLE
Add manual force control for spacecraft

### DIFF
--- a/src/modules/sc_rate_control/SpacecraftRateControl.hpp
+++ b/src/modules/sc_rate_control/SpacecraftRateControl.hpp
@@ -122,6 +122,8 @@ private:
 	// keep setpoint values between updates
 	matrix::Vector3f _acro_rate_max;		/**< max attitude rates in acro mode */
 	matrix::Vector3f _rates_setpoint{};
+	float _manual_torque_max{1.0};
+	float _manual_force_max{1.0};
 
 	float _battery_status_scale{0.0f};
 	matrix::Vector3f _thrust_setpoint{};
@@ -158,6 +160,9 @@ private:
 		(ParamFloat<px4::params::SC_ACRO_EXPO_Y>) _param_sc_acro_expo_y,				/**< expo stick curve shape (yaw) */
 		(ParamFloat<px4::params::SC_ACRO_SUPEXPO>) _param_sc_acro_supexpo,		/**< superexpo stick curve shape (roll & pitch) */
 		(ParamFloat<px4::params::SC_ACRO_SUPEXPOY>) _param_sc_acro_supexpoy,		/**< superexpo stick curve shape (yaw) */
+
+		(ParamFloat<px4::params::SC_MAN_F_MAX>) _param_sc_manual_f_max,
+		(ParamFloat<px4::params::SC_MAN_T_MAX>) _param_sc_manual_t_max,
 
 		(ParamBool<px4::params::SC_BAT_SCALE_EN>) _param_sc_bat_scale_en
 	)

--- a/src/modules/sc_rate_control/sc_rate_control_params.c
+++ b/src/modules/sc_rate_control/sc_rate_control_params.c
@@ -398,3 +398,25 @@ PARAM_DEFINE_FLOAT(SC_ACRO_SUPEXPOY, 0.7f);
  * @group Multicopter Rate Control
  */
 PARAM_DEFINE_INT32(SC_BAT_SCALE_EN, 0);
+
+/**
+ * Manual mode maximum force.
+ *
+ * *
+ * @min 0
+ * @max 1.0
+ * @decimal 2
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(SC_MAN_F_MAX, 1.0f);
+
+/**
+ * Manual mode maximum torque.
+ *
+ * *
+ * @min 0
+ * @max 1.0
+ * @decimal 2
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(SC_MAN_T_MAX, 1.0f);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Added a manual force/torque control mode for spacecraft

Fixes #{Github issue ID}

### Solution
Previously manual mode was treated the same as acro mode.


### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
