### PR TITLE
feat(Docker): Dockerfile for comprising all the apps required for testing the PX4-space-system in a containarized system in any linux file

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -72,7 +72,7 @@ RUN pip3 install vcstool \
     && sudo apt-get install -y \
     $(sort -u $(find . -iname 'packages-'$(lsb_release -cs)'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/gz\|sdf/d' | tr '\n' ' ') && \
     cd $home/Gazebo && \
-    colcon build --merge-install && \
+    colcon build --merge-install --parallel-workers 1 && \
     echo "source $home/Gazebo/install/setup.bash" >> $home/.bashrc
 
 
@@ -131,13 +131,7 @@ WORKDIR $home
 
 ### PX4 simulation software compile
 RUN mkdir -p $home/PX4 && \
-    cd $home/PX4 && \
-    git clone --recursive ${PX4_SOFTWARE_REPO} -b ${PX4_SOFTWARE_BRANCH} && \
-    sudo ./PX4-Space-Systems/Tools/setup/ubuntu.sh -y && \
-    pip3  install -r PX4-Space-Systems/Tools/setup/requirements.txt && \
-    pip3 install --user  symforce &&  \
-    cd PX4-Space-Systems && \
-    make px4_sitl
+    pip3 install --user symforce
 
 ## Set runtime directory environment variable
 ENV XDG_RUNTIME_DIR=/tmp/runtime-root

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -4,6 +4,7 @@ USER root
 ENV user=px4space
 ENV home=/home/$user
 WORKDIR $home
+ENV ROS_DISTRO=humble
 
 RUN apt-get update -y && apt-get upgrade -y &&  apt-get install -y bash
 
@@ -44,6 +45,27 @@ RUN apt update && apt install -y python3-pip lsb-release gnupg curl git \
     cd $home/Gazebo && \
     colcon build --merge-install && \
     echo "source $home/Gazebo/install/setup.bash" >> $home/.bashrc
+
+
+RUN apt-get update -y && apt-get install -y git python3-rosdep && \
+    rosdep fix-permissions && rosdep init && rosdep update && \
+    apt-get install -y ros-${ROS_DISTRO}-ament-cmake && \
+    apt-get install -y python3-colcon-common-extensions && \
+    mkdir -p $HOME/microros_ws/ && cd $HOME/microros_ws/ && \
+    git clone -b $ROS_DISTRO https://github.com/micro-ROS/micro_ros_setup.git src/micro_ros_setup && \
+    rosdep update && \
+    rosdep install --from-paths src --ignore-src -y && \
+    apt-get install -y python3-pip && \
+    . /opt/ros/$ROS_DISTRO/setup.sh && \
+    colcon build && \
+    . install/setup.sh && \
+    ros2 run micro_ros_setup create_firmware_ws.sh host && \
+    ros2 run micro_ros_setup build_firmware.sh && \
+    . install/setup.sh && \
+    ros2 run micro_ros_setup create_agent_ws.sh && \
+    ros2 run micro_ros_setup build_agent.sh && \
+    . install/local_setup.sh && \
+    echo "source $HOME/microros_ws/install/local_setup.bash" >> $HOME/.bashrc
 
 ## QGround Control
 # Install qt version 6.6.3

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -132,7 +132,7 @@ WORKDIR $home
 ### PX4 simulation software compile
 RUN mkdir -p $home/PX4 && \
     cd $home/PX4 && \
-    git clone --recursive https://github.com/SpaceBotsISR/PX4-Space-Systems.git && \
+    git clone --recursive ${PX4_SOFTWARE_REPO} -b ${PX4_SOFTWARE_BRANCH} && \
     sudo ./PX4-Space-Systems/Tools/setup/ubuntu.sh -y && \
     pip3  install -r PX4-Space-Systems/Tools/setup/requirements.txt && \
     pip3 install --user  symforce &&  \

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,36 +1,65 @@
 FROM nvidia/opengl:1.2-glvnd-runtime-ubuntu22.04
 
-USER root
+## Arguments for selection of the PX4 software repository and their respective branch, this makes it easier to switch without needing to change the Dockerfile
+ARG PX4_SOFTWARE_REPO=https://github.com/DISCOWER/PX4-Space-Systems.git
+ARG PX4_SOFTWARE_BRANCH=master
+
 ENV user=px4space
 ENV home=/home/$user
-WORKDIR $home
 ENV ROS_DISTRO=humble
 
-RUN apt-get update -y && apt-get upgrade -y &&  apt-get install -y bash
+WORKDIR $home
 
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y \
+    bash \
+    sudo \
+    wget \
+    curl \
+    tzdata \
+    python3-pip \
+    lsb-release \
+    gnupg \
+    git \
+    mesa-utils \
+    libgl1-mesa-dri \
+    libegl1-mesa \
+    libgles2-mesa \
+    libglx-mesa0 \
+    libglx0 \
+    nvidia-utils-460 \
+    libnvidia-gl-470 && \
+    ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    dpkg-reconfigure --frontend noninteractive tzdata
+
+## Create non root user and give it sudo permissions
+RUN useradd -m -s /bin/bash px4space  \
+    && usermod -aG sudo px4space \
+    && echo 'px4space ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && chown -R px4space:px4space $home
+
+## Switch to non root user
 ## Install ROS2
-RUN apt-get update -y && apt-get install -y curl tzdata \
-    && ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime \
-    && dpkg-reconfigure -f noninteractive tzdata \
-    && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null \
-    && apt-get update -y \
-    && apt-get upgrade -y \
-    && apt-get install ros-humble-desktop -y
+RUN  sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
+    && sudo  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null \
+    && sudo apt-get update -y \
+    && sudo apt-get upgrade -y \
+    && sudo apt-get install -y ros-humble-desktop python3-rosdep
+
 
 RUN echo "source /opt/ros/humble/setup.bash" >> $home/.bashrc
 RUN ["/bin/bash", "-c", "source $home/.bashrc"]
 
 ## Install Gazebo
-RUN apt update && apt install -y python3-pip lsb-release gnupg curl git \
-    && pip3 install vcstool \
+RUN pip3 install vcstool \
     && pip3 install -U colcon-common-extensions \
     && pip3 show vcstool | grep Location \
     && pip3 show colcon-common-extensions | grep Location \
     && sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros2-latest.list' \
     && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add - \
-    && apt-get update -y \
-    && apt-get install -y python3-vcstool python3-colcon-common-extensions \
+    && sudo apt-get update -y \
+    && sudo apt-get install -y python3-vcstool python3-colcon-common-extensions \
     && mkdir -p $home/Gazebo/src \
     && cd $home/Gazebo/src \
     && curl -O https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-garden.yaml \
@@ -39,23 +68,22 @@ RUN apt update && apt install -y python3-pip lsb-release gnupg curl git \
     && vcs import < collection-garden.yaml \
     && curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
-    && apt-get update \
-    && apt-get install -y \
+    && sudo apt-get update \
+    && sudo apt-get install -y \
     $(sort -u $(find . -iname 'packages-'$(lsb_release -cs)'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/gz\|sdf/d' | tr '\n' ' ') && \
     cd $home/Gazebo && \
     colcon build --merge-install && \
     echo "source $home/Gazebo/install/setup.bash" >> $home/.bashrc
 
 
-RUN apt-get update -y && apt-get install -y git python3-rosdep && \
-    rosdep fix-permissions && rosdep init && rosdep update && \
+## Install micro-ROS
+RUN  rosdep fix-permissions &&  rosdep init &&  rosdep update && \
     apt-get install -y ros-${ROS_DISTRO}-ament-cmake && \
     apt-get install -y python3-colcon-common-extensions && \
-    mkdir -p $HOME/microros_ws/ && cd $HOME/microros_ws/ && \
+    mkdir -p $home/microros_ws/ && cd $home/microros_ws/ && \
     git clone -b $ROS_DISTRO https://github.com/micro-ROS/micro_ros_setup.git src/micro_ros_setup && \
     rosdep update && \
     rosdep install --from-paths src --ignore-src -y && \
-    apt-get install -y python3-pip && \
     . /opt/ros/$ROS_DISTRO/setup.sh && \
     colcon build && \
     . install/setup.sh && \
@@ -65,28 +93,33 @@ RUN apt-get update -y && apt-get install -y git python3-rosdep && \
     ros2 run micro_ros_setup create_agent_ws.sh && \
     ros2 run micro_ros_setup build_agent.sh && \
     . install/local_setup.sh && \
-    echo "source $HOME/microros_ws/install/local_setup.bash" >> $HOME/.bashrc
+    echo "source $home/microros_ws/install/local_setup.bash" >> $home/.bashrc
 
-## QGround Control
+
+RUN pip install aqtinstall
+ENV PATH="$home/.local/bin:$PATH"
 # Install qt version 6.6.3
-RUN pip install aqtinstall && \
-    aqt install-qt --outputdir $home/qt linux desktop 6.6.3 gcc_64 -m qtcharts qtconnectivity qtlocation qtmultimedia qtpositioning qtsensors qtserialport qtspeech qtshadertools qt5compat qtquick3d
+RUN aqt install-qt --outputdir $home/qt linux desktop 6.6.3 gcc_64 -m qtcharts qtconnectivity qtlocation qtmultimedia qtpositioning qtsensors qtserialport qtspeech qtshadertools qt5compat qtquick3d
 
 ENV PATH=$home/qt/6.6.3/gcc_64/bin:$PATH
 ENV LD_LIBRARY_PATH=$home/qt/6.6.3/gcc_64/lib:$LD_LIBRARY_PATH
 ENV QT_PLUGIN_PATH=$home/qt/6.6.3/gcc_64/lib/pkgconfig:$PKG_CONFIG_PATH
 
+USER px4space
+
+RUN sudo chown -R px4space:px4space $home
+ENV PATH=$home/.local/bin:$PATH
 RUN mkdir -p $home/QGroundControl && \
     cd $home/QGroundControl && \
     git clone --recursive --depth=1 https://github.com/DISCOWER/qgroundcontrol.git && \
-    bash ./qgroundcontrol/tools/setup/install-dependencies-debian.sh && \
+    sudo bash ./qgroundcontrol/tools/setup/install-dependencies-debian.sh && \
     cd qgroundcontrol && \
     cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug && \
     cmake --build build --config Debug && \
     pwd && \
     cp ./build/QGroundControl $home/QGroundControlApp
 
-## PX4 messages compile
+### PX4 messages compile
 RUN mkdir -p $home/PX4/ros2_ws/src && \
     cd $home/PX4/ros2_ws/src && \
     git clone --recursive --depth=1 https://github.com/PX4/px4_msgs.git && \
@@ -94,41 +127,17 @@ RUN mkdir -p $home/PX4/ros2_ws/src && \
     . /opt/ros/humble/setup.sh && colcon build --symlink-install && \
     echo "source $home/PX4/ros2_ws/install/setup.bash" >> $home/.bashrc
 
-RUN apt-get update && apt-get install -y sudo wget
+WORKDIR $home
 
-## PX4 related stuff
+### PX4 simulation software compile
 RUN mkdir -p $home/PX4 && \
     cd $home/PX4 && \
     git clone --recursive https://github.com/SpaceBotsISR/PX4-Space-Systems.git && \
-    ./PX4-Space-Systems/Tools/setup/ubuntu.sh -y
+    sudo ./PX4-Space-Systems/Tools/setup/ubuntu.sh -y && \
+    pip3  install -r PX4-Space-Systems/Tools/setup/requirements.txt && \
+    pip3 install --user  symforce &&  \
+    cd PX4-Space-Systems && \
+    make px4_sitl
 
+## Set runtime directory environment variable
 ENV XDG_RUNTIME_DIR=/tmp/runtime-root
-
-RUN apt-get update && apt-get install -y \
-  mesa-utils \
-  libgl1-mesa-dri \
-  nvidia-utils-460
-
-# Install necessary Mesa libraries
-RUN apt-get update && apt-get install -y \
-  mesa-utils \
-  libegl1-mesa \
-  libgles2-mesa \
-  libglx-mesa0 \
-  libglx0 \
-  nvidia-utils-460 \
-  libnvidia-gl-470  # Or the matching version of your driver
-
-# Set runtime directory environment variable
-ENV XDG_RUNTIME_DIR=/tmp/runtime-root
-
-
-# Create a user and group with specific IDs
-# Create a user and group with specific IDs
-RUN groupadd -r px4space && useradd -r -g px4space px4space
-
-# Set the user to own the home directory (optional)
-RUN chown -R px4space:px4space /home/px4space
-
-# Switch to non-root user
-USER px4space

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,0 +1,112 @@
+FROM nvidia/opengl:1.2-glvnd-runtime-ubuntu22.04
+
+USER root
+ENV user=px4space
+ENV home=/home/$user
+WORKDIR $home
+
+RUN apt-get update -y && apt-get upgrade -y &&  apt-get install -y bash
+
+## Install ROS2
+RUN apt-get update -y && apt-get install -y curl tzdata \
+    && ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime \
+    && dpkg-reconfigure -f noninteractive tzdata \
+    && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null \
+    && apt-get update -y \
+    && apt-get upgrade -y \
+    && apt-get install ros-humble-desktop -y
+
+RUN echo "source /opt/ros/humble/setup.bash" >> $home/.bashrc
+RUN ["/bin/bash", "-c", "source $home/.bashrc"]
+
+## Install Gazebo
+RUN apt update && apt install -y python3-pip lsb-release gnupg curl git \
+    && pip3 install vcstool \
+    && pip3 install -U colcon-common-extensions \
+    && pip3 show vcstool | grep Location \
+    && pip3 show colcon-common-extensions | grep Location \
+    && sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros2-latest.list' \
+    && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add - \
+    && apt-get update -y \
+    && apt-get install -y python3-vcstool python3-colcon-common-extensions \
+    && mkdir -p $home/Gazebo/src \
+    && cd $home/Gazebo/src \
+    && curl -O https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-garden.yaml \
+    && sed -i "s|gz-sim7|pr-spacecraft-thrusters|" collection-garden.yaml \
+    && sed -i 's|https://github.com/gazebosim/gz-sim|https://github.com/DISCOWER/gz-sim.git|' collection-garden.yaml \
+    && vcs import < collection-garden.yaml \
+    && curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y \
+    $(sort -u $(find . -iname 'packages-'$(lsb_release -cs)'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/gz\|sdf/d' | tr '\n' ' ') && \
+    cd $home/Gazebo && \
+    colcon build --merge-install && \
+    echo "source $home/Gazebo/install/setup.bash" >> $home/.bashrc
+
+## QGround Control
+# Install qt version 6.6.3
+RUN pip install aqtinstall && \
+    aqt install-qt --outputdir $home/qt linux desktop 6.6.3 gcc_64 -m qtcharts qtconnectivity qtlocation qtmultimedia qtpositioning qtsensors qtserialport qtspeech qtshadertools qt5compat qtquick3d
+
+ENV PATH=$home/qt/6.6.3/gcc_64/bin:$PATH
+ENV LD_LIBRARY_PATH=$home/qt/6.6.3/gcc_64/lib:$LD_LIBRARY_PATH
+ENV QT_PLUGIN_PATH=$home/qt/6.6.3/gcc_64/lib/pkgconfig:$PKG_CONFIG_PATH
+
+RUN mkdir -p $home/QGroundControl && \
+    cd $home/QGroundControl && \
+    git clone --recursive --depth=1 https://github.com/DISCOWER/qgroundcontrol.git && \
+    bash ./qgroundcontrol/tools/setup/install-dependencies-debian.sh && \
+    cd qgroundcontrol && \
+    cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug && \
+    cmake --build build --config Debug && \
+    pwd && \
+    cp ./build/QGroundControl $home/QGroundControlApp
+
+## PX4 messages compile
+RUN mkdir -p $home/PX4/ros2_ws/src && \
+    cd $home/PX4/ros2_ws/src && \
+    git clone --recursive --depth=1 https://github.com/PX4/px4_msgs.git && \
+    cd $home/PX4/ros2_ws && \
+    . /opt/ros/humble/setup.sh && colcon build --symlink-install && \
+    echo "source $home/PX4/ros2_ws/install/setup.bash" >> $home/.bashrc
+
+RUN apt-get update && apt-get install -y sudo wget
+
+## PX4 related stuff
+RUN mkdir -p $home/PX4 && \
+    cd $home/PX4 && \
+    git clone --recursive https://github.com/SpaceBotsISR/PX4-Space-Systems.git && \
+    ./PX4-Space-Systems/Tools/setup/ubuntu.sh -y
+
+ENV XDG_RUNTIME_DIR=/tmp/runtime-root
+
+RUN apt-get update && apt-get install -y \
+  mesa-utils \
+  libgl1-mesa-dri \
+  nvidia-utils-460
+
+# Install necessary Mesa libraries
+RUN apt-get update && apt-get install -y \
+  mesa-utils \
+  libegl1-mesa \
+  libgles2-mesa \
+  libglx-mesa0 \
+  libglx0 \
+  nvidia-utils-460 \
+  libnvidia-gl-470  # Or the matching version of your driver
+
+# Set runtime directory environment variable
+ENV XDG_RUNTIME_DIR=/tmp/runtime-root
+
+
+# Create a user and group with specific IDs
+# Create a user and group with specific IDs
+RUN groupadd -r px4space && useradd -r -g px4space px4space
+
+# Set the user to own the home directory (optional)
+RUN chown -R px4space:px4space /home/px4space
+
+# Switch to non-root user
+USER px4space

--- a/Dockerfiles/README.md
+++ b/Dockerfiles/README.md
@@ -1,0 +1,42 @@
+# PX4 Space System docker container
+
+## Overview
+This docker file is used as a way to containerize the simulation environment of PX4 space systems. The simulation run in Ubuntu 22.04 container and uses the new gazebo garden as a simulation engine.
+
+If it is intended to use with ROS (inside the container) you should use ROS2 humble.
+
+## Software packed inside
+
+Inside the container you have packed Gazebo Garden, ros2 humble, micro ros agent, px4 msgs, qt versioon 6.6.3 and QGroundControl (with custom plugin for gzç-sim7).
+
+## Compiling
+
+Compiling the docker is rather simple you must ensure that you have [docker installed](https://docs.docker.com/engine/install/), after this simply build the container, as you can see in the command bellow you can specify the link and the branch for the PX4 git, this allow for more modularity when using in fork of the main work. **Be aware that when changing the branch or link you will need to compile the full container, and this is a lengthy process**
+
+```
+docker build -t px4 --build-arg PX4_SOFTWARE_REPO=https://github.com/SpaceBotsISR/PX4-Space-Systems.git --build-arg PX4_SOFTWARE_BRANCH=pr-space_cobot .
+```
+
+In the computer where this was developed the build process toke around 20 minutes, and needed 16GB of RAM and 16GB of swap space and during the gazebo compilation process the full 16 cores were occupied with build the docker.
+
+After compiling you now need to create the container, this can e done with 
+```
+docker run -it --gpus all \\n  --network=host --ipc=host \\n  -e DISPLAY=$DISPLAY \\n  -e NVIDIA_VISIBLE_DEVICES=all \\n  -e NVIDIA_DRIVER_CAPABILITIES=all \\n  -e QT_X11_NO_MITSHM=1 \\n  -v /tmp/.X11-unix:/tmp/.X11-unix:rw \\n  -v /dev/dri:/dev/dri \\n  -e XDG_RUNTIME_DIR=/tmp/runtime-root \\n  --runtime=nvidia \\n  -v /home/andret/ISR:/home/px4space/ISR \\n  --name px4_cont px4
+```
+
+Most of the flags are used are to pass a gpu to docker and e able to use it for running the gazebo simulation, if you dont have a gpu, or is not a nvidia gpu i recomend removing the flags, since the base container is from nvidia in this docker. An extra folder is also passed to the docker, remove this if you dont want to have the need to it.
+
+## Using the container
+
+The current test done to the simulation enviomnent envolve
+ - Gazebo and QGroundControl running inside the docker container
+ - Gazebo, QGroundControl and ros2 nodes running inside the docker
+ - Gazebo, micro-ros and ros2 nodes inside this docker, with QGroundControl in the host machine and more ros2 node in an external container 
+
+When you open the docker this is the result of the ls command 
+```
+Documents  ISR	QGroundControl	   aqtinstall.log  qt
+Gazebo	   PX4	QGroundControlApp  microros_ws	   ros2_ws
+```
+
+The QGroundControlApp is the execulable, and the simulation toll are accesible through PX4/PX4-Space-Systems

--- a/Dockerfiles/README.md
+++ b/Dockerfiles/README.md
@@ -2,12 +2,13 @@
 
 ## Overview
 This docker file is used as a way to containerize the simulation environment of PX4 space systems. The simulation run in Ubuntu 22.04 container and uses the new gazebo garden as a simulation engine.
+Even tho the work is containerized, you still need to clone the repository to your own computer, since it is easier to work with shared folders, rather than cloning the repository to inside the docker.
 
 If it is intended to use with ROS (inside the container) you should use ROS2 humble.
 
 ## Software packed inside
 
-Inside the container you have packed Gazebo Garden, ros2 humble, micro ros agent, px4 msgs, qt versioon 6.6.3 and QGroundControl (with custom plugin for gzç-sim7).
+Inside the container you have packed Gazebo Garden, ros2 humble, micro ros agent, px4 msgs, qt version 6.6.3 and QGroundControl (with custom plugin for gz-sim7).
 
 ## Compiling
 
@@ -19,16 +20,44 @@ docker build -t px4 --build-arg PX4_SOFTWARE_REPO=https://github.com/SpaceBotsIS
 
 In the computer where this was developed the build process toke around 20 minutes, and needed 16GB of RAM and 16GB of swap space and during the gazebo compilation process the full 16 cores were occupied with build the docker.
 
-After compiling you now need to create the container, this can e done with 
+After compiling you now need to create the container, this can be done with the followint command:
 ```
-docker run -it --gpus all \\n  --network=host --ipc=host \\n  -e DISPLAY=$DISPLAY \\n  -e NVIDIA_VISIBLE_DEVICES=all \\n  -e NVIDIA_DRIVER_CAPABILITIES=all \\n  -e QT_X11_NO_MITSHM=1 \\n  -v /tmp/.X11-unix:/tmp/.X11-unix:rw \\n  -v /dev/dri:/dev/dri \\n  -e XDG_RUNTIME_DIR=/tmp/runtime-root \\n  --runtime=nvidia \\n  -v /home/andret/ISR:/home/px4space/ISR \\n  --name px4_cont px4
+docker run -it --gpus all \  
+  --network=host --ipc=host \  
+  -e DISPLAY=$DISPLAY \
+  -e NVIDIA_VISIBLE_DEVICES=all \
+  -e NVIDIA_DRIVER_CAPABILITIES=all \
+  -e QT_X11_NO_MITSHM=1 \
+  -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+  -v /dev/dri:/dev/dri \
+  -e XDG_RUNTIME_DIR=/tmp/runtime-root \
+  --runtime=nvidia \
+  -v /home/andret/ISR/PX4-Space-Systems:/home/px4space/PX4/PX4-Space-Systems \
+  --name px4_cont px4
 ```
 
-Most of the flags are used are to pass a gpu to docker and e able to use it for running the gazebo simulation, if you dont have a gpu, or is not a nvidia gpu i recomend removing the flags, since the base container is from nvidia in this docker. An extra folder is also passed to the docker, remove this if you dont want to have the need to it.
+Most of the flags are used are to pass a gpu to docker and be able to use it for running the gazebo simulation, if you don' t have a gpu, or is not a nvidia gpu I recommend removing the flags, since the base container is from nvidia in this docker. The last flag passed with the **-v"** options used to forward to the container the PX4-Space-Systems folder in the root computer, here we can see an example of how it is done in my computer, beware you will need to change the full path before **':'** as the path after this is relative to the interior of the container.
+
+### First time running.
+
+Since now we forward the **PX4-Space-Systems** folder to the docker container, the first time running the docker some actions are required,  you will need to install all the dependencies as well as compile the contents of the repository. To this simply execute the next command.  
+```bash
+pushd PX4/PX4-Space-Systems && \
+	././Tools/setup/ubuntu.sh -y && \
+	pip3 install -r Tools/setup/requirements.txt && \
+	make px4_sitl && \
+	popd
+```
+
+After this the container should be ready to use with the normal functionalities of the simulation tool, to test run the following command in a terminal of the container
+```bash
+make px4_sitl gz_x500
+```
+And verify if a gazebo window opens with the x_500 robot in the simulation environment. 
 
 ## Using the container
 
-The current test done to the simulation enviomnent envolve
+The current test done to the simulation environment involve
  - Gazebo and QGroundControl running inside the docker container
  - Gazebo, QGroundControl and ros2 nodes running inside the docker
  - Gazebo, micro-ros and ros2 nodes inside this docker, with QGroundControl in the host machine and more ros2 node in an external container 
@@ -39,4 +68,4 @@ Documents  ISR	QGroundControl	   aqtinstall.log  qt
 Gazebo	   PX4	QGroundControlApp  microros_ws	   ros2_ws
 ```
 
-The QGroundControlApp is the execulable, and the simulation toll are accesible through PX4/PX4-Space-Systems
+The QGroundControlApp is the executable, and the simulation toll are accessible through PX4/PX4-Space-Systems


### PR DESCRIPTION
The objective of this branch was to create a dockerfile than when compiled had all the necessary dependencies to run the simulator, this means that the Gazebo  (with the custom gz-sim package), the  custom QGroundControl, as well as the necessary ROS environment (ROS2 humble and the micro ros) for the simulation. 

Currently the build stage of the docker is doing all the necessary steps, but more testing is necessary to make sure all the correct decencies. 

Also the cloning of the PX4 repository to inside the docker container should be changed to a simple use of a shared folder in docker with the ``` -v ``` flag on the docker run but some problem were found when this was being done