### PR TITLE
Feat: Namespaces for hardware upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Here for PX4 Space?
 
 To test the SITL environment, run:
-  
+
   ```bash
   make px4_sitl gazebo-classic_2d_spacecraft__frictionless
   ```
@@ -18,12 +18,24 @@ Some of our changes are making their way to PRs on Gazebo, PX4-Autopilot and MAV
 Soon we will provide docker environments that you can use to build the binaries and deploy them. In case you follow the PX4 development guide on how to build the source code, the same instructions also apply to our fork.
 
 ### How can I use Gazebo Garden or up?
-To this end, you will need to build Gazebo Garden from source - [instructions here](https://gazebosim.org/docs/garden/install_ubuntu_src) - and change the `gz-sim7` package with our version available in DISCOWER [GitHub](https://github.com/DISCOWER/gz-sim/tree/pr-spacecraft-thrusters), and make sure you use the branch `pr-spacecraft-thrusters`. 
+To this end, you will need to build Gazebo Garden from source - [instructions here](https://gazebosim.org/docs/garden/install_ubuntu_src) - and change the `gz-sim7` package with our version available in DISCOWER [GitHub](https://github.com/DISCOWER/gz-sim/tree/pr-spacecraft-thrusters), and make sure you use the branch `pr-spacecraft-thrusters`.
 
 Then, you should build the PX4 Space Systems source code with
   ```bash
   make px4_sitl gz_spacecraft_2d
   ```
+
+### How can I use namespaces?
+Namespaces work in both simulation and on hardware.
+To give your controller a namespace in simulation, run:
+  ```
+  PX4_UXRCE_DDS_NS=<namespace> make px4_sitl gz_spacecraft_2d
+  ```
+To upload to micro-controller, e.g. Pixhawk 6X, and give it a namespace, run:
+  ```
+  PX4_UXRCE_DDS_NS=<namespace> make px4_fmu-v6x_spacecraft upload
+  ```
+Topics will then be in the form "/\<namespace\>/fmu/..."
 
 ### How can I use the custom QGroundControl?
 Please follow the source build instructions for [QGroundControl](https://docs.qgroundcontrol.com/master/en/qgc-dev-guide/getting_started/index.html) but use our version of QGroundControl [available here](https://github.com/DISCOWER/qgroundcontrol).

--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -8,7 +8,7 @@ jinja2>=2.8
 jsonschema
 kconfiglib
 lxml
-matplotlib>=3.0.*
+matplotlib>=3.0
 numpy>=1.13
 nunavut>=1.1.0
 packaging

--- a/src/modules/uxrce_dds_client/dds_topics.h.em
+++ b/src/modules/uxrce_dds_client/dds_topics.h.em
@@ -86,6 +86,9 @@ void SendTopicsSubs::reset() {
 
 void SendTopicsSubs::update(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId best_effort_stream_id, uxrObjectId participant_id, const char *client_namespace)
 {
+	if (!client_namespace || client_namespace[0] == '\0') {
+		client_namespace = "@(namespace)";
+	}
 	int64_t time_offset_us = session->time_offset / 1000; // ns -> us
 
 	alignas(sizeof(uint64_t)) char topic_data[max_topic_size];
@@ -166,6 +169,9 @@ static void on_topic_update(uxrSession *session, uxrObjectId object_id, uint16_t
 
 bool RcvTopicsPubs::init(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId reliable_in_stream_id, uxrStreamId best_effort_in_stream_id, uxrObjectId participant_id, const char *client_namespace)
 {
+	if (!client_namespace || client_namespace[0] == '\0') {
+		client_namespace = "@(namespace)";
+	}
 @[    for idx, sub in enumerate(subscriptions + subscriptions_multi)]@
 	{
 			uint16_t queue_depth = orb_get_queue_size(ORB_ID(@(sub['simple_base_type']))) * 2; // use a bit larger queue size than internal

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -83,8 +83,6 @@ with open(args.yaml_file, 'r') as file:
     msg_map = yaml.safe_load(file)
 
 # Read namespace and set default if not present
-# env_namespace = os.getenv('PX4_UXRCE_DDS_NS', None)
-# namespace = env_namespace if env_namespace is not None else msg_map.get('namespace', '')
 namespace = os.getenv('PX4_UXRCE_DDS_NS', '')
 
 merged_em_globals = {}

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -82,10 +82,18 @@ if not os.path.exists(folder_name):
 with open(args.yaml_file, 'r') as file:
     msg_map = yaml.safe_load(file)
 
+# Read namespace and set default if not present
+# env_namespace = os.getenv('PX4_UXRCE_DDS_NS', None)
+# namespace = env_namespace if env_namespace is not None else msg_map.get('namespace', '')
+namespace = os.getenv('PX4_UXRCE_DDS_NS', '')
+
 merged_em_globals = {}
 all_type_includes = []
 
 def process_message_type(msg_type):
+    # Add namespace to topic
+    msg_type['topic'] = f"/{namespace}{msg_type['topic']}" if namespace else msg_type['topic']
+
     # eg TrajectoryWaypoint from px4_msgs::msg::TrajectoryWaypoint
     simple_base_type = msg_type['type'].split('::')[-1]
 
@@ -98,6 +106,8 @@ def process_message_type(msg_type):
     msg_type['dds_type'] = msg_type['type'].replace("::msg::", "::msg::dds_::") + "_"
     # topic_simple: eg vehicle_status
     msg_type['topic_simple'] = msg_type['topic'].split('/')[-1]
+
+merged_em_globals['namespace'] = namespace
 
 pubs_not_empty = msg_map['publications'] is not None
 if pubs_not_empty:

--- a/src/modules/uxrce_dds_client/utilities.hpp
+++ b/src/modules/uxrce_dds_client/utilities.hpp
@@ -25,13 +25,12 @@ uxrObjectId topic_id_from_orb(ORB_ID orb_id, uint8_t instance = 0)
 
 static bool generate_topic_name(char *topic, const char *client_namespace, const char *direction, const char *name)
 {
-	if (client_namespace != nullptr) {
-		int ret = snprintf(topic, TOPIC_NAME_SIZE, "rt/%s/fmu/%s/%s", client_namespace, direction, name);
-		return (ret > 0 && ret < TOPIC_NAME_SIZE);
+	if (client_namespace && client_namespace[0] != '\0') {
+		snprintf(topic, TOPIC_NAME_SIZE, "rt/%s/fmu/%s/%s", client_namespace, direction, name);
+	} else {
+		snprintf(topic, TOPIC_NAME_SIZE, "rt/fmu/%s/%s", direction, name);
 	}
-
-	int ret = snprintf(topic, TOPIC_NAME_SIZE, "rt/fmu/%s/%s", direction, name);
-	return (ret > 0 && ret < TOPIC_NAME_SIZE);
+	return true;
 }
 
 static bool create_data_writer(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrObjectId participant_id,


### PR DESCRIPTION
**Added the option to set up the vehicle namespace during firmware upload to the microcontroller via the global variable `PX4_UXRCE_DDS_NS`.**
Previously, this functionality was only available in SITL.
This update affects only the _uxrce_dds_client_ module, which will now use the specified namespace if provided during firmware upload. The namespace setting persists across reboots.