### PR TITLE
KTH Space Lab world: reintroduction with server.config plugin fix

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -96,6 +96,7 @@ if(gz-transport_FOUND)
 		windy
 		baylands
   		lawn
+		kthspacelab
 	)
 
 	# find corresponding airframes

--- a/src/modules/simulation/gz_bridge/gz_env.sh.in
+++ b/src/modules/simulation/gz_bridge/gz_env.sh.in
@@ -2,5 +2,8 @@
 
 export PX4_GZ_MODELS=@PX4_SOURCE_DIR@/Tools/simulation/gz/models
 export PX4_GZ_WORLDS=@PX4_SOURCE_DIR@/Tools/simulation/gz/worlds
+export PX4_GZ_SERVER_CONFIG=@PX4_SOURCE_DIR@/src/modules/simulation/gz_bridge/server.config
 
 export GZ_SIM_RESOURCE_PATH=$GZ_SIM_RESOURCE_PATH:$PX4_GZ_MODELS:$PX4_GZ_WORLDS
+export GZ_SIM_SYSTEM_PLUGIN_PATH=$GZ_SIM_SYSTEM_PLUGIN_PATH:$PX4_GZ_PLUGINS
+export GZ_SIM_SERVER_CONFIG_PATH=$PX4_GZ_SERVER_CONFIG

--- a/src/modules/simulation/gz_bridge/server.config
+++ b/src/modules/simulation/gz_bridge/server.config
@@ -1,0 +1,20 @@
+<server_config>
+  <plugins>
+    <plugin entity_name="*" entity_type="world" filename="gz-sim-physics-system" name="gz::sim::systems::Physics"/>
+    <plugin entity_name="*" entity_type="world" filename="gz-sim-user-commands-system" name="gz::sim::systems::UserCommands"/>
+    <plugin entity_name="*" entity_type="world" filename="gz-sim-scene-broadcaster-system" name="gz::sim::systems::SceneBroadcaster"/>
+    <plugin entity_name="*" entity_type="world" filename="gz-sim-contact-system" name="gz::sim::systems::Contact"/>
+    <plugin entity_name="*" entity_type="world" filename="gz-sim-imu-system" name="gz::sim::systems::Imu"/>
+    <plugin entity_name="*" entity_type="world" filename="gz-sim-air-pressure-system" name="gz::sim::systems::AirPressure"/>
+    <plugin entity_name="*" entity_type="world" filename="gz-sim-air-speed-system" name="gz::sim::systems::AirSpeed"/>
+    <plugin entity_name="*" entity_type="world" filename="gz-sim-apply-link-wrench-system" name="gz::sim::systems::ApplyLinkWrench"/>
+    <plugin entity_name="*" entity_type="world" filename="gz-sim-navsat-system" name="gz::sim::systems::NavSat"/>
+    <plugin entity_name="*" entity_type="world" filename="gz-sim-magnetometer-system" name="gz::sim::systems::Magnetometer"/>
+    <plugin entity_name="*" entity_type="world" filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <!-- plugin entity_name="*" entity_type="world" filename="libOpticalFlowSystem.so" name="custom::OpticalFlowSystem"/> -->
+    <!-- plugin entity_name="*" entity_type="world" filename="libGstCameraSystem.so" name="custom::GstCameraSystem"/> -->
+    <!-- <plugin entity_name="*" entity_type="world" filename="libTemplatePlugin.so" name="custom::TemplateSystem"/> -->
+  </plugins>
+</server_config>


### PR DESCRIPTION
This PR reintroduces the KTH Space Lab world and the submodule update from #30, along with the plugin configuration fix from #31.

PR #30 was originally merged and later reverted.

**Included:**

* Updates `px4-gazebo-models` to include `kthspacelab.sdf`
* Adds `kthspacelab.sdf` to the CMake build
* Adds `server.config` with Gazebo system plugin definitions
* Updates `gz_env.sh.in` to use `GZ_SIM_SERVER_CONFIG_PATH` for plugin loading

These changes restore the original feature and fix, keeping us consistent with upstream PX4-Autopilot.

**Note:**
After pulling, run
```bash
make px4_sitl
```
once to update `gz_env.sh` in `build/`.

---
If approved, #30 and #31 will be closed.